### PR TITLE
Fix Spotify ZIP parsing and silence CLI warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 2. Запустите утилиту и укажите один или несколько архивов/JSON‑файлов, а также минимальное количество минут прослушивания.
 
 ```bash
-python -m album_analyzer.cli export \
+python -m album_analyzer.cli \
     "~/Downloads/MyData.zip" \
     --min-minutes 120 \
     --output albums.json

--- a/album_analyzer/__init__.py
+++ b/album_analyzer/__init__.py
@@ -1,8 +1,16 @@
-from .cli import app
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .exporter import export_albums, load_albums
 from .models import AlbumListening
 from .parser import aggregate_archives, filter_by_minutes
 from .release_date import enrich_with_release_dates
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
+    from .cli import app as _cli_app
+
+    app = _cli_app
 
 __all__ = [
     "AlbumListening",
@@ -13,3 +21,15 @@ __all__ = [
     "enrich_with_release_dates",
     "app",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "app":
+        from .cli import app as cli_app
+
+        return cli_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial delegation
+    return sorted(list(__all__))

--- a/album_analyzer/parser.py
+++ b/album_analyzer/parser.py
@@ -11,10 +11,13 @@ from .models import AlbumListening
 
 LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_JSON_SUFFIXES = (
-    "endsong_",
-    "Streaming_History_Audio",
-    "StreamingHistory",
+SUPPORTED_JSON_SUFFIXES = tuple(
+    suffix.lower()
+    for suffix in (
+        "endsong_",
+        "Streaming_History_Audio",
+        "StreamingHistory",
+    )
 )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,6 @@
+import json
 from pathlib import Path
+from zipfile import ZipFile
 
 from album_analyzer.parser import aggregate_archives, filter_by_minutes
 
@@ -17,3 +19,35 @@ def test_aggregate_archives(tmp_path: Path) -> None:
     filtered = filter_by_minutes(albums, minimum_minutes=5)
     assert len(filtered) == 1
     assert filtered[0].album == "Test Album"
+
+
+def test_aggregate_archives_spotify_zip(tmp_path: Path) -> None:
+    archive = tmp_path / "spotify_history.zip"
+    entries = [
+        {
+            "master_metadata_album_album_name": "Album",
+            "master_metadata_album_artist_name": "Artist",
+            "master_metadata_track_name": "Track One",
+            "ms_played": 600_000,
+        },
+        {
+            "albumName": "Album",
+            "artistName": "Artist",
+            "trackName": "Track Two",
+            "msPlayed": 120_000,
+        },
+    ]
+    with ZipFile(archive, "w") as handle:
+        handle.writestr(
+            "Spotify Extended Streaming History/Streaming_History_Audio_2024.json",
+            json.dumps(entries),
+        )
+
+    albums = aggregate_archives([archive])
+    assert len(albums) == 1
+
+    album = albums[0]
+    assert album.album == "Album"
+    assert album.artist == "Artist"
+    assert round(album.minutes, 1) == 12.0
+    assert album.tracks == {"Track One", "Track Two"}


### PR DESCRIPTION
## Summary
- make ZIP parsing case-insensitive so Spotify Extended Streaming History archives are processed correctly
- add a regression test covering a mixed-key Spotify ZIP archive
- lazily import the Typer app to avoid the runtime warning and refresh the README example command

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1261deb308331af5f20b169358db9