### PR TITLE
Ensure desktop save dialog opens on Windows

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -41,6 +41,21 @@ def build(name: str, entry_script: Path, windowed: bool, clean: bool) -> Path:
         name,
         "--onefile",
     ]
+
+    if entry_script.name == "run_desktop.py":
+        # pywebview loads its platform backends dynamically, so we need to
+        # tell PyInstaller to bundle them explicitly when building the desktop
+        # executable. Otherwise the app launches without opening a window.
+        args.extend(
+            [
+                "--hidden-import",
+                "webview",
+                "--collect-submodules",
+                "webview",
+                "--collect-data",
+                "webview",
+            ]
+        )
     if windowed:
         args.append("--noconsole")
     if clean:

--- a/run_desktop.py
+++ b/run_desktop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import sys
 import threading
 import time
 from contextlib import suppress
@@ -60,12 +61,93 @@ class _DesktopApi:
 
         self._window = window
 
-    def save_albums_json(self, filename: str, content: str) -> dict[str, str]:
-        """Prompt the user to save the generated JSON file to disk."""
+    def _prompt_with_win32(
+        self, filename: str
+    ) -> tuple[Path | None, bool, str | None]:
+        """Show a native Windows save dialog using the Win32 API."""
+
+        if not sys.platform.startswith("win"):
+            return None, False, "win32: недоступно на этой платформе"
+
+        try:  # pragma: no cover - requires Windows to exercise for real
+            import ctypes
+            from ctypes import wintypes
+        except Exception as exc:  # pragma: no cover - depends on runtime availability
+            return None, False, f"win32: {exc}"
+
+        try:  # pragma: no cover - only executed on Windows
+            comdlg32 = ctypes.windll.comdlg32
+            user32 = ctypes.windll.user32
+        except Exception as exc:  # pragma: no cover - depends on Win32 availability
+            return None, False, f"win32: {exc}"
+
+        class OPENFILENAMEW(ctypes.Structure):  # pragma: no cover - structure mirrors Win32
+            _fields_ = [
+                ("lStructSize", wintypes.DWORD),
+                ("hwndOwner", wintypes.HWND),
+                ("hInstance", wintypes.HINSTANCE),
+                ("lpstrFilter", wintypes.LPCWSTR),
+                ("lpstrCustomFilter", wintypes.LPWSTR),
+                ("nMaxCustFilter", wintypes.DWORD),
+                ("nFilterIndex", wintypes.DWORD),
+                ("lpstrFile", wintypes.LPWSTR),
+                ("nMaxFile", wintypes.DWORD),
+                ("lpstrFileTitle", wintypes.LPWSTR),
+                ("nMaxFileTitle", wintypes.DWORD),
+                ("lpstrInitialDir", wintypes.LPCWSTR),
+                ("lpstrTitle", wintypes.LPCWSTR),
+                ("Flags", wintypes.DWORD),
+                ("nFileOffset", wintypes.WORD),
+                ("nFileExtension", wintypes.WORD),
+                ("lpstrDefExt", wintypes.LPCWSTR),
+                ("lCustData", wintypes.LPARAM),
+                ("lpfnHook", ctypes.c_void_p),
+                ("lpTemplateName", wintypes.LPCWSTR),
+                ("pvReserved", ctypes.c_void_p),
+                ("dwReserved", wintypes.DWORD),
+                ("FlagsEx", wintypes.DWORD),
+            ]
+
+        buffer = ctypes.create_unicode_buffer(4096)
+        default_name = Path(filename).name or "albums.json"
+        buffer.value = default_name.replace("\0", "") or "albums.json"
+
+        ofn = OPENFILENAMEW()
+        ofn.lStructSize = ctypes.sizeof(OPENFILENAMEW)
+        ofn.hwndOwner = user32.GetForegroundWindow()
+        filter_spec = "JSON файл (*.json)\0*.json\0Все файлы (*.*)\0*.*\0\0"
+        ofn.lpstrFilter = filter_spec
+        ofn.nFilterIndex = 1
+        ofn.lpstrFile = ctypes.cast(buffer, wintypes.LPWSTR)
+        ofn.nMaxFile = len(buffer)
+        ofn.lpstrTitle = "Сохранить albums.json"
+        ofn.Flags = 0x00000002 | 0x00000008 | 0x00000800  # overwrite prompt, keep cwd, existing paths
+        ofn.lpstrDefExt = "json"
+
+        try:  # pragma: no cover - real execution requires Windows GUI
+            success = comdlg32.GetSaveFileNameW(ctypes.byref(ofn))
+        except Exception as exc:  # pragma: no cover - Win32 specific failure
+            return None, False, f"win32: {exc}"
+
+        if success:
+            selected = buffer.value.strip()
+            if not selected:
+                return None, True, None
+            return Path(selected), False, None
+
+        error_code = comdlg32.CommDlgExtendedError()
+        if error_code:
+            return None, False, f"win32: ошибка диалога сохранения (код 0x{error_code:08x})"
+        return None, True, None
+
+    def _prompt_with_pywebview(
+        self, filename: str
+    ) -> tuple[Path | None, bool, str | None]:
+        """Try to let pywebview open a save dialog."""
 
         window = self._window
         if window is None:
-            return {"status": "error", "message": "Окно ещё не готово."}
+            return None, False, "Окно ещё не готово."
 
         try:  # pragma: no cover - depends on GUI backend
             selection = window.create_file_dialog(
@@ -74,10 +156,10 @@ class _DesktopApi:
                 file_types=("JSON файл (*.json)", "Все файлы (*.*)"),
             )
         except Exception as exc:  # pragma: no cover - backend specific
-            return {"status": "error", "message": str(exc)}
+            return None, False, f"pywebview: {exc}"
 
         if not selection:
-            return {"status": "cancelled"}
+            return None, True, None
 
         if isinstance(selection, (list, tuple)):
             destination = selection[0]
@@ -85,14 +167,116 @@ class _DesktopApi:
             destination = selection
 
         if not destination:
-            return {"status": "cancelled"}
+            return None, True, None
+
+        return Path(destination), False, None
+
+    def _prompt_with_tkinter(
+        self, filename: str
+    ) -> tuple[Path | None, bool, str | None]:
+        """Fallback to a tkinter-based save dialog if available."""
+
+        try:  # pragma: no cover - optional dependency at runtime
+            import tkinter as tk
+            from tkinter import filedialog
+        except Exception as exc:  # pragma: no cover - depends on platform availability
+            return None, False, f"tkinter: {exc}"
 
         try:
-            Path(destination).write_text(content, encoding="utf-8")
-        except OSError as exc:  # pragma: no cover - filesystem specific
-            return {"status": "error", "message": str(exc)}
+            root = tk.Tk()
+        except Exception as exc:  # pragma: no cover - depends on platform availability
+            return None, False, f"tkinter: {exc}"
 
-        return {"status": "saved"}
+        selection: str | tuple[str, ...] | None = None
+
+        try:
+            root.withdraw()
+            try:
+                root.update_idletasks()
+            except Exception:  # pragma: no cover - best effort to avoid focus issues
+                pass
+            try:
+                root.attributes("-topmost", True)
+            except Exception:  # pragma: no cover - platform dependent
+                pass
+
+            selection = filedialog.asksaveasfilename(
+                title="Сохранить файл",
+                defaultextension=".json",
+                initialfile=filename,
+                filetypes=[("JSON файл (*.json)", "*.json"), ("Все файлы (*.*)", "*.*")],
+            )
+        except Exception as exc:  # pragma: no cover - UI toolkit specific
+            return None, False, f"tkinter: {exc}"
+        finally:
+            try:
+                root.destroy()
+            except Exception:  # pragma: no cover - platform dependent cleanup
+                pass
+
+        if not selection:
+            return None, True, None
+
+        if isinstance(selection, (tuple, list)):
+            destination = selection[0]
+        else:
+            destination = selection
+
+        if not destination:
+            return None, True, None
+
+        return Path(destination), False, None
+
+    def save_albums_json(self, filename: str, content: str) -> dict[str, str]:
+        """Prompt the user to save the generated JSON file to disk."""
+
+        errors: list[str] = []
+
+        prompt_order = []
+        if sys.platform.startswith("win"):
+            prompt_order.extend(
+                [
+                    lambda: self._prompt_with_win32(filename),
+                    lambda: self._prompt_with_tkinter(filename),
+                    lambda: self._prompt_with_pywebview(filename),
+                ]
+            )
+        else:
+            prompt_order.extend(
+                [
+                    lambda: self._prompt_with_pywebview(filename),
+                    lambda: self._prompt_with_tkinter(filename),
+                ]
+            )
+
+        for prompt in prompt_order:
+            destination, cancelled, error = prompt()
+            if error:
+                errors.append(error)
+                continue
+
+            if destination is not None:
+                try:
+                    destination.write_text(content, encoding="utf-8")
+                except OSError as exc:  # pragma: no cover - filesystem specific
+                    errors.append(str(exc))
+                    continue
+                return {"status": "saved"}
+
+            if cancelled:
+                return {"status": "cancelled"}
+
+        if errors:
+            # Deduplicate errors while keeping order for readability.
+            seen: set[str] = set()
+            unique_errors = []
+            for message in errors:
+                if message and message not in seen:
+                    seen.add(message)
+                    unique_errors.append(message)
+            return {"status": "error", "message": "; ".join(unique_errors)}
+
+        return {"status": "error", "message": "Не удалось сохранить файл."}
 
 
 def _wait_for_server(port: int, timeout: float = 10.0) -> None:

--- a/tests/test_run_desktop.py
+++ b/tests/test_run_desktop.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from run_desktop import _DesktopApi
+
+
+@pytest.fixture
+def desktop_api() -> _DesktopApi:
+    return _DesktopApi(SimpleNamespace())
+
+
+def test_save_albums_json_prefers_win32(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, desktop_api: _DesktopApi) -> None:
+    calls: list[str] = []
+
+    def fake_win32(filename: str):
+        calls.append("win32")
+        return tmp_path / filename, False, None
+
+    def fail_if_called(_filename: str):  # pragma: no cover - defensive guard
+        raise AssertionError("Fallback dialog should not be used when Win32 succeeds")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(desktop_api, "_prompt_with_win32", fake_win32)
+    monkeypatch.setattr(desktop_api, "_prompt_with_tkinter", fail_if_called)
+    monkeypatch.setattr(desktop_api, "_prompt_with_pywebview", fail_if_called)
+
+    result = desktop_api.save_albums_json("albums.json", "payload")
+
+    assert result == {"status": "saved"}
+    assert (tmp_path / "albums.json").read_text("utf-8") == "payload"
+    assert calls == ["win32"]
+
+
+def test_save_albums_json_falls_back_from_win32(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, desktop_api: _DesktopApi) -> None:
+    order: list[str] = []
+    destination = tmp_path / "albums.json"
+
+    def failing_win32(_filename: str):
+        order.append("win32")
+        return None, False, "win32 failure"
+
+    def tkinter_success(filename: str):
+        order.append("tk")
+        assert filename == "albums.json"
+        return destination, False, None
+
+    def fail_if_called(_filename: str):  # pragma: no cover - defensive guard
+        raise AssertionError("pywebview fallback should not run once tkinter succeeds")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(desktop_api, "_prompt_with_win32", failing_win32)
+    monkeypatch.setattr(desktop_api, "_prompt_with_tkinter", tkinter_success)
+    monkeypatch.setattr(desktop_api, "_prompt_with_pywebview", fail_if_called)
+
+    result = desktop_api.save_albums_json("albums.json", "payload")
+
+    assert result == {"status": "saved"}
+    assert destination.read_text("utf-8") == "payload"
+    assert order == ["win32", "tk"]
+
+
+def test_save_albums_json_non_windows_order(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, desktop_api: _DesktopApi) -> None:
+    order: list[str] = []
+    destination = tmp_path / "albums.json"
+
+    def pywebview_success(filename: str):
+        order.append("pywebview")
+        return destination, False, None
+
+    def fail_if_called(_filename: str):  # pragma: no cover - defensive guard
+        raise AssertionError("tkinter fallback should not run when pywebview succeeds")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(desktop_api, "_prompt_with_pywebview", pywebview_success)
+    monkeypatch.setattr(desktop_api, "_prompt_with_tkinter", fail_if_called)
+
+    result = desktop_api.save_albums_json("albums.json", "payload")
+
+    assert result == {"status": "saved"}
+    assert destination.read_text("utf-8") == "payload"
+    assert order == ["pywebview"]


### PR DESCRIPTION
## Summary
- add a Win32-based save dialog to the desktop API so the packaged app always triggers File Explorer on Windows before falling back to tkinter or pywebview
- cover the new dialog ordering with tests to confirm Windows and non-Windows flows use the right prompts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d148fd200c8331b4d6d188841f2dfc